### PR TITLE
keep track of client input inside Textbox

### DIFF
--- a/api/src/main/java/net/pl3x/guithium/api/action/actions/player/screen/element/TextboxChangedAction.java
+++ b/api/src/main/java/net/pl3x/guithium/api/action/actions/player/screen/element/TextboxChangedAction.java
@@ -1,0 +1,77 @@
+package net.pl3x.guithium.api.action.actions.player.screen.element;
+
+import net.pl3x.guithium.api.action.RegisteredHandler;
+import net.pl3x.guithium.api.action.actions.Cancellable;
+import net.pl3x.guithium.api.gui.Screen;
+import net.pl3x.guithium.api.gui.element.Textbox;
+import net.pl3x.guithium.api.player.WrappedPlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Action that fires when a textbox is changed.
+ */
+public class TextboxChangedAction extends ElementAction implements Cancellable {
+    private static final List<RegisteredHandler> handlers = new ArrayList<>();
+
+    private String value;
+    private boolean cancelled;
+
+    /**
+     * Creates a new action for when a textbox is changed.
+     *
+     * @param player Player that performed the action
+     * @param screen Screen action was performed on
+     * @param textbox Textbox action was performed on
+     * @param value  New value of textbox
+     */
+    public TextboxChangedAction(WrappedPlayer player, Screen screen, Textbox textbox, String value) {
+        super(player, screen, textbox);
+        this.value = value;
+    }
+
+    /**
+     * Get the textbox that was changed.
+     *
+     * @return Changed textbox
+     */
+    @NotNull
+    public Textbox getElement() {
+        return (Textbox) super.getElement();
+    }
+
+    /**
+     * Get the new value of this textbox change.
+     *
+     * @return New textbox value
+     */
+    public String getValue() {
+        return this.value;
+    }
+
+    /**
+     * Set the new value of this textbox change.
+     *
+     * @param value New textbox value
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    @Override
+    public @NotNull List<RegisteredHandler> getHandlers() {
+        return handlers;
+    }
+}

--- a/api/src/main/java/net/pl3x/guithium/api/gui/element/Textbox.java
+++ b/api/src/main/java/net/pl3x/guithium/api/gui/element/Textbox.java
@@ -3,14 +3,18 @@ package net.pl3x.guithium.api.gui.element;
 import com.google.common.base.Preconditions;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import java.util.Objects;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.pl3x.guithium.api.Key;
+import net.pl3x.guithium.api.gui.Screen;
 import net.pl3x.guithium.api.gui.Vec2;
 import net.pl3x.guithium.api.json.JsonObjectWrapper;
+import net.pl3x.guithium.api.player.WrappedPlayer;
+import net.pl3x.guithium.api.util.QuadConsumer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
  * Represents an interactable textbox for user input.
@@ -24,6 +28,8 @@ public class Textbox extends Rect {
     private Boolean editable;
     private Integer textColor;
     private Integer textColorUneditable;
+    private OnChange onChange = (screen, textbox, player, value) -> {
+    };
 
     /**
      * Creates a new textbox.
@@ -240,6 +246,29 @@ public class Textbox extends Rect {
         this.textColorUneditable = color;
     }
 
+    /**
+     * Get the action to execute when the textbox is changed.
+     * <p>
+     * If null, no change action will be used.
+     *
+     * @return OnClick action
+     */
+    @Nullable
+    public OnChange onChange() {
+        return this.onChange;
+    }
+
+    /**
+     * Set the action to execute when the textbox is changed.
+     * <p>
+     * If null, no change action will be used.
+     *
+     * @param onChange OnChange action
+     */
+    public void onChange(@Nullable OnChange onChange) {
+        this.onChange = onChange;
+    }
+
     @Override
     @NotNull
     public JsonElement toJson() {
@@ -365,6 +394,7 @@ public class Textbox extends Rect {
         private Boolean editable;
         private Integer textColor;
         private Integer textColorUneditable;
+        private OnChange onChange;
 
         /**
          * Create a new textbox element builder.
@@ -593,6 +623,32 @@ public class Textbox extends Rect {
         }
 
         /**
+         * Get the action to execute when the textbox is changed.
+         * <p>
+         * If null, no change action will be used.
+         *
+         * @return OnChanged action
+         */
+        @Nullable
+        public OnChange onChange() {
+            return this.onChange;
+        }
+
+        /**
+         * Set the action to execute when the textbox is changed.
+         * <p>
+         * If null, no change action will be used.
+         *
+         * @param onChange OnChange action
+         * @return This builder
+         */
+        @NotNull
+        public Builder onChange(@Nullable Textbox.OnChange onChange) {
+            this.onChange = onChange;
+            return this;
+        }
+
+        /**
          * Build a new textbox element from the current properties in this builder.
          *
          * @return New textbox element
@@ -600,7 +656,23 @@ public class Textbox extends Rect {
         @Override
         @NotNull
         public Textbox build() {
-            return new Textbox(getKey(), getPos(), getAnchor(), getOffset(), getRotation(), getScale(), getSize(), getValue(), getSuggestion(), isBordered(), canLoseFocus(), getMaxLength(), isEditable(), getTextColor(), getTextColorUneditable());
+            final Textbox textbox = new Textbox(getKey(), getPos(), getAnchor(), getOffset(), getRotation(), getScale(), getSize(), getValue(), getSuggestion(), isBordered(), canLoseFocus(), getMaxLength(), isEditable(), getTextColor(), getTextColorUneditable());
+            textbox.onChange(this.onChange);
+            return textbox;
         }
     }
+
+    @FunctionalInterface
+    public interface OnChange extends QuadConsumer<Screen, Textbox, WrappedPlayer, String> {
+        /**
+         * Called when a textbox is changed.
+         *
+         * @param screen Active screen where slider was changed
+         * @param textbox Textbox that was changed
+         * @param player Player that changed the slider
+         * @param value  New value of the slider
+         */
+        void accept(@NotNull Screen screen, @NotNull Textbox textbox, @NotNull WrappedPlayer player, @NotNull String value);
+    }
+
 }

--- a/api/src/main/java/net/pl3x/guithium/api/network/NetworkHandler.java
+++ b/api/src/main/java/net/pl3x/guithium/api/network/NetworkHandler.java
@@ -1,9 +1,6 @@
 package net.pl3x.guithium.api.network;
 
 import com.google.common.io.ByteArrayDataInput;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
 import net.pl3x.guithium.api.Guithium;
 import net.pl3x.guithium.api.Key;
 import net.pl3x.guithium.api.network.packet.ButtonClickPacket;
@@ -15,9 +12,14 @@ import net.pl3x.guithium.api.network.packet.OpenScreenPacket;
 import net.pl3x.guithium.api.network.packet.Packet;
 import net.pl3x.guithium.api.network.packet.RadioTogglePacket;
 import net.pl3x.guithium.api.network.packet.SliderChangePacket;
+import net.pl3x.guithium.api.network.packet.TextboxChangePacket;
 import net.pl3x.guithium.api.network.packet.TexturesPacket;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * Represents a network handler.
@@ -43,6 +45,7 @@ public abstract class NetworkHandler {
         registerHandler(OpenScreenPacket.KEY, OpenScreenPacket::new);
         registerHandler(RadioTogglePacket.KEY, RadioTogglePacket::new);
         registerHandler(SliderChangePacket.KEY, SliderChangePacket::new);
+        registerHandler(TextboxChangePacket.KEY, TextboxChangePacket::new);
         registerHandler(TexturesPacket.KEY, TexturesPacket::new);
     }
 

--- a/api/src/main/java/net/pl3x/guithium/api/network/PacketListener.java
+++ b/api/src/main/java/net/pl3x/guithium/api/network/PacketListener.java
@@ -8,6 +8,7 @@ import net.pl3x.guithium.api.network.packet.HelloPacket;
 import net.pl3x.guithium.api.network.packet.OpenScreenPacket;
 import net.pl3x.guithium.api.network.packet.RadioTogglePacket;
 import net.pl3x.guithium.api.network.packet.SliderChangePacket;
+import net.pl3x.guithium.api.network.packet.TextboxChangePacket;
 import net.pl3x.guithium.api.network.packet.TexturesPacket;
 import org.jetbrains.annotations.NotNull;
 
@@ -70,6 +71,13 @@ public interface PacketListener {
      * @param packet Slider change packet to handle
      */
     void handleSliderChange(@NotNull SliderChangePacket packet);
+
+    /**
+     * Handle Textbox change packet.
+     *
+     * @param packet Textbox change packet to handle
+     */
+    void handleTextboxChange(@NotNull TextboxChangePacket packet);
 
     /**
      * Handle texture preload packet.

--- a/api/src/main/java/net/pl3x/guithium/api/network/packet/TextboxChangePacket.java
+++ b/api/src/main/java/net/pl3x/guithium/api/network/packet/TextboxChangePacket.java
@@ -1,0 +1,93 @@
+package net.pl3x.guithium.api.network.packet;
+
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import net.pl3x.guithium.api.Key;
+import net.pl3x.guithium.api.gui.Screen;
+import net.pl3x.guithium.api.gui.element.Textbox;
+import net.pl3x.guithium.api.network.PacketListener;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a packet containing textbox change information.
+ */
+public class TextboxChangePacket extends Packet {
+    /**
+     * Unique identifying key
+     */
+    public static final Key KEY = Key.of("packet:textbox_change");
+
+    private final Key screen;
+    private final Key textbox;
+    private final String value;
+
+    /**
+     * Creates a new textbox change packet.
+     *
+     * @param screen Screen textbox was changed on
+     * @param textbox Textbox that was changed
+     * @param value  New value of textbox
+     */
+    public TextboxChangePacket(@NotNull Screen screen, @NotNull Textbox textbox, String value) {
+        super(KEY);
+        this.screen = screen.getKey();
+        this.textbox = textbox.getKey();
+        this.value = value;
+    }
+
+    /**
+     * Creates a new textbox change packet.
+     *
+     * @param in Input byte array
+     */
+    public TextboxChangePacket(@NotNull ByteArrayDataInput in) {
+        super(KEY);
+        this.screen = Key.of(in.readUTF());
+        this.textbox = Key.of(in.readUTF());
+        this.value = in.readUTF();
+    }
+
+    /**
+     * Get the screen the textbox was changed on.
+     *
+     * @return Textbox's screen
+     */
+    @NotNull
+    public Key getScreen() {
+        return this.screen;
+    }
+
+    /**
+     * Get the textbox that was changed.
+     *
+     * @return Changed textbox
+     */
+    @NotNull
+    public Key getTextbox() {
+        return this.textbox;
+    }
+
+    /**
+     * Get the new value of the textbox.
+     *
+     * @return Textbox's new value
+     */
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public void handle(@NotNull PacketListener listener) {
+        listener.handleTextboxChange(this);
+    }
+
+    @Override
+    @NotNull
+    public ByteArrayDataOutput write() {
+        ByteArrayDataOutput out = out(this);
+        out.writeUTF(getScreen().toString());
+        out.writeUTF(getTextbox().toString());
+        out.writeUTF(getValue());
+        return out;
+    }
+}

--- a/bukkit/src/main/java/net/pl3x/guithium/plugin/network/BukkitPacketListener.java
+++ b/bukkit/src/main/java/net/pl3x/guithium/plugin/network/BukkitPacketListener.java
@@ -1,6 +1,5 @@
 package net.pl3x.guithium.plugin.network;
 
-import java.util.Map;
 import net.pl3x.guithium.api.Guithium;
 import net.pl3x.guithium.api.Key;
 import net.pl3x.guithium.api.action.actions.player.PlayerJoinedAction;
@@ -9,11 +8,13 @@ import net.pl3x.guithium.api.action.actions.player.screen.element.ButtonClickedA
 import net.pl3x.guithium.api.action.actions.player.screen.element.CheckboxToggledAction;
 import net.pl3x.guithium.api.action.actions.player.screen.element.RadioToggledAction;
 import net.pl3x.guithium.api.action.actions.player.screen.element.SliderChangedAction;
+import net.pl3x.guithium.api.action.actions.player.screen.element.TextboxChangedAction;
 import net.pl3x.guithium.api.gui.Screen;
 import net.pl3x.guithium.api.gui.element.Button;
 import net.pl3x.guithium.api.gui.element.Checkbox;
 import net.pl3x.guithium.api.gui.element.Radio;
 import net.pl3x.guithium.api.gui.element.Slider;
+import net.pl3x.guithium.api.gui.element.Textbox;
 import net.pl3x.guithium.api.gui.texture.Texture;
 import net.pl3x.guithium.api.network.PacketListener;
 import net.pl3x.guithium.api.network.packet.ButtonClickPacket;
@@ -24,10 +25,13 @@ import net.pl3x.guithium.api.network.packet.HelloPacket;
 import net.pl3x.guithium.api.network.packet.OpenScreenPacket;
 import net.pl3x.guithium.api.network.packet.RadioTogglePacket;
 import net.pl3x.guithium.api.network.packet.SliderChangePacket;
+import net.pl3x.guithium.api.network.packet.TextboxChangePacket;
 import net.pl3x.guithium.api.network.packet.TexturesPacket;
 import net.pl3x.guithium.api.player.WrappedPlayer;
 import net.pl3x.guithium.plugin.player.BukkitPlayer;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 public class BukkitPacketListener implements PacketListener {
     private final WrappedPlayer player;
@@ -176,6 +180,30 @@ public class BukkitPacketListener implements PacketListener {
         Slider.OnChange onChange = slider.onChange();
         if (onChange != null) {
             onChange.accept(screen, slider, this.player, action.getValue());
+        }
+    }
+
+    @Override
+    public void handleTextboxChange(@NotNull final TextboxChangePacket packet) {
+        Screen screen = this.player.getCurrentScreen();
+        if (screen == null || !screen.getKey().equals(packet.getScreen())) {
+            return;
+        }
+        if (!(screen.getElements().get(packet.getTextbox()) instanceof Textbox textbox)) {
+            return;
+        }
+        TextboxChangedAction action = new TextboxChangedAction(this.player, screen, textbox, packet.getValue());
+        Guithium.api().getActionRegistry().callAction(action);
+        if (action.isCancelled()) {
+            return;
+        }
+        textbox.setValue(action.getValue());
+        if (packet.getValue() != action.getValue() && !packet.getValue().equals(action.getValue())) {
+            textbox.send(this.player);
+        }
+        Textbox.OnChange onChange = textbox.onChange();
+        if (onChange != null) {
+            onChange.accept(screen, textbox, this.player, action.getValue());
         }
     }
 

--- a/fabric/src/main/java/net/pl3x/guithium/fabric/gui/element/RenderableTextbox.java
+++ b/fabric/src/main/java/net/pl3x/guithium/fabric/gui/element/RenderableTextbox.java
@@ -8,6 +8,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.pl3x.guithium.api.gui.Vec2;
 import net.pl3x.guithium.api.gui.element.Textbox;
+import net.pl3x.guithium.api.network.packet.TextboxChangePacket;
+import net.pl3x.guithium.fabric.Guithium;
 import net.pl3x.guithium.fabric.gui.screen.RenderableScreen;
 import org.jetbrains.annotations.NotNull;
 
@@ -89,6 +91,12 @@ public class RenderableTextbox extends RenderableWidget {
         }
         if (getElement().getTextColorUneditable() != null) {
             editbox.setTextColorUneditable(getElement().getTextColorUneditable());
+        }
+        if (getElement().onChange() != null) {
+            editbox.setResponder(value -> {
+                Guithium.instance().getNetworkHandler().getConnection()
+                    .send(new TextboxChangePacket(getScreen().getScreen(), getElement(), value));
+            });
         }
     }
 }

--- a/fabric/src/main/java/net/pl3x/guithium/fabric/net/FabricPacketListener.java
+++ b/fabric/src/main/java/net/pl3x/guithium/fabric/net/FabricPacketListener.java
@@ -12,6 +12,7 @@ import net.pl3x.guithium.api.network.packet.HelloPacket;
 import net.pl3x.guithium.api.network.packet.OpenScreenPacket;
 import net.pl3x.guithium.api.network.packet.RadioTogglePacket;
 import net.pl3x.guithium.api.network.packet.SliderChangePacket;
+import net.pl3x.guithium.api.network.packet.TextboxChangePacket;
 import net.pl3x.guithium.api.network.packet.TexturesPacket;
 import net.pl3x.guithium.fabric.Guithium;
 import net.pl3x.guithium.fabric.gui.element.RenderableElement;
@@ -104,6 +105,12 @@ public class FabricPacketListener implements PacketListener {
 
     @Override
     public void handleSliderChange(@NotNull SliderChangePacket packet) {
+        // server does not send this packet to the client
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    public void handleTextboxChange(@NotNull final TextboxChangePacket packet) {
         // server does not send this packet to the client
         throw new UnsupportedOperationException("Not supported.");
     }


### PR DESCRIPTION
> *Re-opened from different branch, continuation of #2.*

Scope of this PR is to integrate client-side `Textbox` with the server.

Whenever client modifies contents of their `Textbox`, a packet is sent to the server with an update.

Some parts of code, especially API, was "inspired" by the `Slider` element. Implementation relies on NMS `EditBox`'s `responder` field - not entirely sure what is it used for (I can only assume client-side actions) - but generally gets the job done, at least on the first glance.

**Following API classes are added:**
- `Textbox.OnChange implements QuadConsumer<...>` - Similar to `Slider.OnChange`.
- `TextboxChangePacket` - Packet containing information about `Textbox` input field changes.
- `TextboxChangedAction` - Action that fires when `Textbox` is changed.

**Following API methods are added:**
- `Textbox#onChange : OnChange` - Gets `OnChange` functional interface associated with this `Textbox`.
- `Textbox#onChange(OnChange) : void` - Gets `OnChange` functional interface associated with this `Textbox`.
- ...above methods are also present on `Textbox.Builder`.

**Question and concerns about implementation details:**
- Right now, `onChange` is also called when clicking on a field. Looks like vanilla behavior when handling `responder`. I'm not sure if and what should I do about that.

<br>

I tested this PR with the **[following code](https://gist.github.com/Grabsky/42cb46367161bc74e502b3cc250c9a47)**.

https://github.com/BillyGalbreath/Guithium/assets/44530932/a14b2b31-a118-403f-a446-c7829c0982bc